### PR TITLE
finished the profile page and fixed stuff in the community tab

### DIFF
--- a/src/app/community/globalFeed/page.tsx
+++ b/src/app/community/globalFeed/page.tsx
@@ -577,6 +577,14 @@ const GlobalFeed = ({ user }: { user: User | null }) => {
     }
   }, [messages.length]);
 
+  // Add this new useEffect after the existing one around line 578
+  useEffect(() => {
+    // Ensure initial scroll to bottom when the component first loads with messages
+    if (!loading && messages.length > 0) {
+      chatEndRef.current?.scrollIntoView();
+    }
+  }, [loading, messages.length]);
+
   // Update the handleSendMessage function to handle case-insensitive symbols
   const handleSendMessage = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -796,73 +804,77 @@ const GlobalFeed = ({ user }: { user: User | null }) => {
       {/* Left Column - Global Chat */}
       <div className="grid grid-cols-1 lg:grid-cols-[2fr_1fr] gap-6">
 
-        <div className="bg-gray-800/50 backdrop-blur-sm rounded-2xl p-5 shadow-lg border border-white/10 flex flex-col ">
+        <div className="bg-gray-800/50 backdrop-blur-sm rounded-2xl p-5 shadow-lg border border-white/10 flex flex-col">
           <h2 className="text-xl font-bold text-white mb-4">Global Market Chat</h2>
 
-          {/* Chat Messages */}
-          <div className="flex-grow overflow-y-auto mb-4 pr-2 custom-scrollbar">
-            <div className="space-y-4">
-              {messages.map((message) => (
-                <div
-                  key={message.id}
-                  className={`flex items-start gap-3 ${message.user.id === (user?.id || 'guest')
-                    ? 'bg-blue-600/20 rounded-xl p-3'
-                    : 'bg-gray-700/30 rounded-xl p-3'
-                    }`}
-                >
-                  <div className="flex-shrink-0 w-10 h-10 rounded-full overflow-hidden bg-gray-700 flex items-center justify-center">
-                    {message.user.image ? (
-                      <Image
-                        src={message.user.image}
-                        alt={message.user.name}
-                        width={40}
-                        height={40}
-                        className="object-cover"
-                      />
-                    ) : (
-                      <UserCircleIcon className="w-10 h-10 text-gray-400" />
-                    )}
-                  </div>
-
-                  <div className="flex-grow">
-                    <div className="flex justify-between items-center mb-1">
-                      <span className="font-semibold text-white">{message.user.name}</span>
-                      <span className="text-xs text-gray-400">{formatTimestamp(message.timestamp)}</span>
-                    </div>
-                    {formatMessageContent(message.content)}
-                  </div>
-                </div>
-              ))}
-              <div ref={chatEndRef} />
-            </div>
-          </div>
-
-          {/* Message Input */}
-          {user ? (
-            <form onSubmit={handleSendMessage} className="mt-auto">
-              <div className="flex gap-2">
-                <input
-                  type="text"
-                  value={newMessage}
-                  onChange={(e) => setNewMessage(e.target.value)}
-                  placeholder="Share your market insights... (Use # to send a stock. Ex. #NVDA)"
-                  className="flex-grow px-4 py-3 rounded-xl bg-gray-700/30 border border-white/5 focus:border-blue-500/50 focus:outline-none transition-colors text-white"
-                />
-                <button
-                  type="submit"
-                  disabled={!newMessage.trim()}
-                  className="px-6 py-3 bg-blue-600 rounded-xl text-white font-medium hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  Send
-                </button>
+          {/* Fixed height scrollable container for messages */}
+          <div className="mb-4 h-[500px] overflow-y-auto pr-2 custom-scrollbar bg-gray-700/20 rounded-xl p-4 border border-white/5">
+            {messages.length === 0 ? (
+              <div className="flex flex-col items-center justify-center h-full">
+                <p className="text-gray-400">No messages yet. Be the first to send one!</p>
               </div>
+            ) : (
+              <div className="space-y-3">
+                {messages.map((message) => (
+                  <div
+                    key={message.id}
+                    className={`flex items-start gap-3 ${message.user.id === (user?.id || 'guest')
+                      ? 'bg-blue-600/20 rounded-xl p-3'
+                      : 'bg-gray-700/30 rounded-xl p-3'
+                      }`}
+                  >
+                    <div className="flex-shrink-0 w-10 h-10 rounded-full overflow-hidden bg-gray-700 flex items-center justify-center">
+                      {message.user.image ? (
+                        <Image
+                          src={message.user.image}
+                          alt={message.user.name}
+                          width={40}
+                          height={40}
+                          className="object-cover"
+                        />
+                      ) : (
+                        <UserCircleIcon className="w-10 h-10 text-gray-400" />
+                      )}
+                    </div>
+
+                    <div className="flex-grow">
+                      <div className="flex justify-between items-center mb-1">
+                        <span className="font-semibold text-white">{message.user.name}</span>
+                        <span className="text-xs text-gray-400">{formatTimestamp(message.timestamp)}</span>
+                      </div>
+                      {formatMessageContent(message.content)}
+                    </div>
+                  </div>
+                ))}
+                <div ref={chatEndRef} />
+              </div>
+            )}
+          </div>
+          
+          {/* Message input and send button */}
+          {user ? (
+            <form onSubmit={handleSendMessage} className="flex space-x-2">
+              <input
+                type="text"
+                value={newMessage}
+                onChange={(e) => setNewMessage(e.target.value)}
+                placeholder="Share your market insights... (Use # to send a stock. Ex. #NVDA)"
+                className="flex-grow px-4 py-3 rounded-xl bg-gray-700/30 border border-white/5 focus:border-blue-500/50 focus:outline-none transition-colors text-white"
+              />
+              <button
+                type="submit"
+                disabled={!newMessage.trim()}
+                className="px-6 py-3 bg-blue-600 rounded-xl text-white font-medium hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Send
+              </button>
             </form>
           ) : (
-            <div className="mt-auto bg-gray-700/20 rounded-xl p-4 border border-white/5 text-center">
-              <p className="text-gray-300 mb-3">Login to join the conversation</p>
-              <button
-                onClick={() => router.push('/login-signup')}
-                className="px-6 py-2 bg-blue-600 rounded-lg text-white font-medium hover:bg-blue-700 transition-colors"
+            <div className="bg-gray-700/30 rounded-lg p-3 text-center">
+              <p className="text-gray-400">Please log in to send messages</p>
+              <button 
+                onClick={() => router.push('/login-signup')} 
+                className="mt-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
               >
                 Login
               </button>

--- a/src/app/community/myPage/page.tsx
+++ b/src/app/community/myPage/page.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import TransactionCard from '@/app/components/TransactionCard';
+
+interface MyPageProps {
+  user?: any;
+}
+
+interface Transaction {
+  id: string;
+  userId: string;
+  userEmail: string;
+  userName?: string;
+  stockSymbol: string;
+  quantity: number;
+  price: number;
+  totalCost: number;
+  type: string;
+  timestamp: string | Date;
+  isCurrentUser?: boolean;
+  publicNote?: string;
+  privateNote?: string;
+}
+
+const MyPage: React.FC<MyPageProps> = ({ user }) => {
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [friendEmail, setFriendEmail] = useState('');
+  const [friendError, setFriendError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  // Function to fetch user's transactions
+  const fetchTransactions = async () => {
+    try {
+      const res = await fetch('/api/user/transactions', {
+        headers: {
+          'Cache-Control': 'no-cache, no-store, must-revalidate',
+          'Pragma': 'no-cache'
+        }
+      });
+      const data = await res.json();
+      if (data.success) {
+        setTransactions(data.transactions);
+      }
+      setLoading(false);
+    } catch (error) {
+      console.error('Error fetching transactions:', error);
+      setLoading(false);
+    }
+  };
+
+  // Handle adding a friend
+  const handleAddFriend = async () => {
+    if (!user || !friendEmail) return;
+    try {
+      const res = await fetch('/api/user/add-friend', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: friendEmail }),
+      });
+      const data = await res.json();
+      if (data.success) {
+        setFriendEmail('');
+        setFriendError('');
+      } else {
+        setFriendError(data.error || 'Failed to add friend. Please try again later.');
+      }
+    } catch (error) {
+      setFriendError('Failed to add friend. Please try again later.');
+    }
+  };
+  
+  useEffect(() => {
+    if (user) {
+      fetchTransactions();
+      
+      const intervalId = setInterval(() => {
+        fetchTransactions();
+      }, 30000);
+      
+      return () => clearInterval(intervalId);
+    } else {
+      setLoading(false);
+    }
+  }, [user]);
+
+  if (!user) {
+    return (
+      <div className="flex flex-col space-y-4">
+        <div className="bg-gray-800/50 backdrop-blur-sm rounded-xl p-6 shadow-lg border border-white/10">
+          <h2 className="text-xl font-bold text-white mb-4">My Page</h2>
+          <p className="text-gray-400">Please log in to view your friend activity and add friends.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col space-y-4">
+      <div className="bg-gray-800/50 backdrop-blur-sm rounded-xl p-6 shadow-lg border border-white/10">
+        <h2 className="text-xl font-bold text-white mb-4">My Page</h2>
+        <p className="text-gray-200 mb-6">Welcome back, {user.name || user.email}!</p>
+        
+        {/* Add Friend Section */}
+        <div className="bg-gray-800/50 backdrop-blur-sm rounded-xl p-6 shadow-lg border border-white/10 mb-6">
+          <h3 className="text-lg font-bold text-white mb-4">Add Friend</h3>
+          <div className="flex flex-col gap-2">
+            <input
+              type="email"
+              value={friendEmail}
+              onChange={(e) => setFriendEmail(e.target.value)}
+              placeholder="Friend's Email"
+              className="w-full p-2 rounded-lg bg-gray-700/50 text-white border border-gray-600/50 focus:outline-none focus:border-blue-500"
+            />
+            <button
+              onClick={handleAddFriend}
+              className="w-full py-2 px-4 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              Add Friend
+            </button>
+            {friendError && <div className="text-red-400 mt-2">{friendError}</div>}
+          </div>
+        </div>
+        
+        {/* Friend Activity Section */}
+        <div className="bg-gray-800/50 backdrop-blur-sm rounded-xl p-6 shadow-lg border border-white/10">
+          <h3 className="text-lg font-bold text-white mb-4">Friend Activity</h3>
+          {loading ? (
+            <div className="text-gray-400 text-center py-4">Loading transactions...</div>
+          ) : transactions.length === 0 ? (
+            <div className="text-gray-400 text-center py-4">
+              No trading activity yet. Make a trade or add friends to see their activity here.
+            </div>
+          ) : (
+            <div className="space-y-2 max-h-[600px] overflow-y-auto pr-2 custom-scrollbar">
+              {transactions.map((transaction) => (
+                <TransactionCard key={transaction.id} transaction={transaction} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MyPage; 

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -9,6 +9,7 @@ import { IoIosDocument } from 'react-icons/io';
 import GlobalFeed from './globalFeed/page';
 import Notifications from './notifications/page';
 import Articles from './articles/page';
+import MyPage from './myPage/page';
 
 enum Tab {
   globalFeed = "globalFeed",
@@ -97,6 +98,7 @@ const CommunityPage = () => {
         {activeComponent === Tab.globalFeed && <GlobalFeed user={user} />}
         {activeComponent === Tab.notifications && <Notifications />}
         {activeComponent === Tab.articles && <Articles />}
+        {activeComponent === Tab.myPage && <MyPage user={user} />}
       </div>
     </div>
   );

--- a/src/app/components/TransactionCard.tsx
+++ b/src/app/components/TransactionCard.tsx
@@ -41,16 +41,55 @@ const TransactionCard: React.FC<TransactionCardProps> = ({ transaction }) => {
   );
   
   const displayName = userName || userEmail.split('@')[0];
+
   const isBuy = type === 'BUY';
+  const isSell = type === 'SELL';
+  const isLootboxPurchase = type === 'LOOTBOX';
+  const isLootboxRedeem = type === 'LOOTBOX_REDEEM';
+
   const hasNotes = publicNote || (isCurrentUser && privateNote);
+
+  const getActionVerb = () => {
+    if (isBuy) return 'bought';
+    if (isSell) return 'sold';
+    if (isLootboxPurchase) return 'purchased';
+    if (isLootboxRedeem) return 'redeemed';
+    return 'traded';
+  };
+
+  const getItemDisplayName = () => {
+    if (isLootboxPurchase) return 'Lootbox';
+    if (isLootboxRedeem) return `${stockSymbol} from Lootbox`;
+    return stockSymbol;
+  };
+
+  const getPriceDisplay = () => {
+    if (isLootboxPurchase) return `Cost: $${price.toFixed(2)}`;
+    if (isLootboxRedeem) return `Value: $${price.toFixed(2)}`;
+    return `${quantity} ${quantity === 1 ? 'share' : 'shares'} @ $${price.toFixed(2)}`;
+  };
+
+  const getActionColor = () => {
+    if (isBuy || isLootboxRedeem) return 'bg-green-500';
+    if (isSell) return 'bg-red-500';
+    if (isLootboxPurchase) return 'bg-blue-500';
+    return 'bg-gray-500';
+  };
+
+  const getCostColor = () => {
+    if (isBuy || isLootboxPurchase) return 'text-green-400';
+    if (isSell) return 'text-red-400';
+    if (isLootboxRedeem) return 'text-blue-400';
+    return 'text-gray-400';
+  };
   
   return (
     <div className="bg-gray-800/60 rounded-xl p-4 mb-3 border border-gray-700/50 hover:border-gray-600/50 transition-all duration-200">
       <div className="flex justify-between items-start mb-2">
         <div className="flex items-center">
-          <div className={`w-2 h-2 rounded-full mr-2 ${isBuy ? 'bg-green-500' : 'bg-red-500'}`}></div>
+          <div className={`w-2 h-2 rounded-full mr-2 ${getActionColor()}`}></div>
           <span className="font-semibold text-white">
-            {isCurrentUser ? 'You' : displayName} {isBuy ? 'bought' : 'sold'}
+            {isCurrentUser ? 'You' : displayName} {getActionVerb()}
           </span>
         </div>
         <span className="text-xs text-gray-400">{formattedTime}</span>
@@ -59,13 +98,13 @@ const TransactionCard: React.FC<TransactionCardProps> = ({ transaction }) => {
       <div className="flex justify-between items-center">
         <div>
           <div className="flex items-baseline">
-            <span className="text-lg font-bold text-white">{stockSymbol}</span>
+            <span className="text-lg font-bold text-white">{getItemDisplayName()}</span>
             <span className="text-sm text-gray-300 ml-2">
-              {quantity} {quantity === 1 ? 'share' : 'shares'} @ ${price.toFixed(2)}
+              {getPriceDisplay()}
             </span>
           </div>
         </div>
-        <div className={`text-right ${isBuy ? 'text-green-400' : 'text-red-400'}`}>
+        <div className={`text-right ${getCostColor()}`}>
           <div className="font-bold">${totalCost.toFixed(2)}</div>
         </div>
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -182,3 +182,27 @@
   scrollbar-width: thin;
   scrollbar-color: rgba(75, 85, 99, 0.5) rgba(31, 32, 45, 0.5);
 }
+
+/* Custom scrollbar for recent activity section */
+.custom-scrollbar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: rgba(31, 32, 45, 0.3);
+  border-radius: 4px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(75, 85, 99, 0.4);
+  border-radius: 4px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: rgba(75, 85, 99, 0.7);
+}
+
+.custom-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(75, 85, 99, 0.4) rgba(31, 32, 45, 0.3);
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import { PencilIcon, CheckIcon, XMarkIcon, CameraIcon } from '@heroicons/react/24/solid';
+import { FunnelIcon } from '@heroicons/react/24/outline';
 import Image from 'next/image';
 import { authClient } from "@/lib/auth-client";
 import { toast } from '@/app/hooks/use-toast';
@@ -150,8 +151,14 @@ const ProfilePage = () => {
     const [userAchievements, setUserAchievements] = useState<UserAchievement[]>([]);
     const [UserAchievementsLoading, setUserAchievementsLoading] = useState(true);
 
-    // New state for transactions
     const [transactions, setTransactions] = useState<Transaction[]>([]);
+    const [transactionFilter, setTransactionFilter] = useState<string>('ALL');
+    const [showFilterDropdown, setShowFilterDropdown] = useState<boolean>(false);
+    const filterDropdownRef = useRef<HTMLDivElement>(null);
+
+    const [portfolioValue, setPortfolioValue] = useState<number>(0);
+    const [stockPositions, setStockPositions] = useState<Record<string, { shares: number; averagePrice: number }>>({});
+    const [portfolioLoading, setPortfolioLoading] = useState<boolean>(true);
 
     // Helper function to format timestamps to relative time
     const formatRelativeTime = (dateString: string) => {
@@ -191,8 +198,93 @@ const ProfilePage = () => {
         }
     };
 
+    // Fetch portfolio data
+    const fetchPortfolioData = async () => {
+        try {
+            setPortfolioLoading(true);
+            const response = await fetch('/api/user/portfolio');
+            if (response.ok) {
+                const data = await response.json();
+                
+                // Calculate total portfolio value of stocks only (excluding balance)
+                let totalStockValue = 0;
+                
+                // Add value of all stock positions
+                Object.entries(data.positions).forEach(([symbol, position]: [string, any]) => {
+                    totalStockValue += position.shares * position.averagePrice;
+                });
+                
+                setPortfolioValue(totalStockValue);
+                setStockPositions(data.positions);
+            }
+        } catch (error) {
+            console.error('Error fetching portfolio data:', error);
+        } finally {
+            setPortfolioLoading(false);
+        }
+    };
+
+    // Calculate profit based on transactions
+    const calculateProfit = () => {
+        let buyTotal = 0;
+        let sellTotal = 0;
+        
+        transactions.forEach(transaction => {
+            if (transaction.type === 'BUY') {
+                buyTotal += transaction.price * transaction.quantity;
+            } else if (transaction.type === 'SELL') {
+                sellTotal += transaction.price * transaction.quantity;
+            }
+        });
+        
+        return sellTotal - buyTotal;
+    };
+
+    const calculateWinRate = () => {
+        const stockTransactions: Record<string, Transaction[]> = {};
+
+        const tradingTransactions = transactions.filter(t => t.type === 'BUY' || t.type === 'SELL');
+        
+        if (tradingTransactions.length === 0) return 0;
+
+        tradingTransactions.forEach(transaction => {
+            if (!stockTransactions[transaction.stockSymbol]) {
+                stockTransactions[transaction.stockSymbol] = [];
+            }
+            stockTransactions[transaction.stockSymbol].push(transaction);
+        });
+        
+        let winningTrades = 0;
+        let totalCompletedTrades = 0;
+
+        Object.values(stockTransactions).forEach(stockTxs => {
+            const buys = stockTxs.filter(t => t.type === 'BUY');
+            const sells = stockTxs.filter(t => t.type === 'SELL');
+
+            if (buys.length === 0 || sells.length === 0) return;
+
+            const totalBuyAmount = buys.reduce((sum, t) => sum + (t.price * t.quantity), 0);
+            const totalBuyQuantity = buys.reduce((sum, t) => sum + t.quantity, 0);
+            const avgBuyPrice = totalBuyAmount / totalBuyQuantity;
+            
+            const totalSellAmount = sells.reduce((sum, t) => sum + (t.price * t.quantity), 0);
+            const totalSellQuantity = sells.reduce((sum, t) => sum + t.quantity, 0);
+            const avgSellPrice = totalSellAmount / totalSellQuantity;
+
+            totalCompletedTrades++;
+
+            if (avgSellPrice > avgBuyPrice) {
+                winningTrades++;
+            }
+        });
+        
+        // Calculate win rate percentage
+        return totalCompletedTrades > 0 ? (winningTrades / totalCompletedTrades) * 100 : 0;
+    };
+
     useEffect(() => {
         fetchTransactions();
+        fetchPortfolioData();
     }, []);
 
     useEffect(() => {
@@ -440,6 +532,26 @@ const ProfilePage = () => {
         }
     };
 
+    // Filter transactions based on selected filter
+    const filteredTransactions = transactions.filter(transaction => {
+        if (transactionFilter === 'ALL') return true;
+        return transaction.type === transactionFilter;
+    });
+
+    // Handle click outside to close the filter dropdown
+    useEffect(() => {
+        function handleClickOutside(event: MouseEvent) {
+            if (filterDropdownRef.current && !filterDropdownRef.current.contains(event.target as Node)) {
+                setShowFilterDropdown(false);
+            }
+        }
+
+        document.addEventListener("mousedown", handleClickOutside);
+        return () => {
+            document.removeEventListener("mousedown", handleClickOutside);
+        };
+    }, [filterDropdownRef]);
+
     if (loading) {
         return (
             <div className="min-h-screen bg-gradient-to-r from-gray-900 to-gray-800 flex items-center justify-center">
@@ -568,58 +680,188 @@ const ProfilePage = () => {
                             </div>
                             <div>
                                 <p className="text-sm text-gray-400">Win Rate</p>
-                                <p className="text-2xl font-bold text-green-400">68%</p>
+                                {portfolioLoading ? (
+                                    <div className="h-8 w-20 bg-gray-700/50 animate-pulse rounded"></div>
+                                ) : (
+                                    <p className={`text-2xl font-bold ${calculateWinRate() > 50 ? 'text-green-400' : 'text-red-400'}`}>
+                                        {calculateWinRate().toFixed(0)}%
+                                    </p>
+                                )}
                             </div>
                             <div>
                                 <p className="text-sm text-gray-400">Portfolio Value</p>
-                                <p className="text-2xl font-bold text-white">$24,156</p>
+                                {portfolioLoading ? (
+                                    <div className="h-8 w-24 bg-gray-700/50 animate-pulse rounded"></div>
+                                ) : (
+                                    <p className="text-2xl font-bold text-white">
+                                        ${portfolioValue.toLocaleString(undefined, {
+                                            minimumFractionDigits: 2,
+                                            maximumFractionDigits: 2
+                                        })}
+                                    </p>
+                                )}
                             </div>
                             <div>
                                 <p className="text-sm text-gray-400">Total Profit</p>
-                                <p className="text-2xl font-bold text-green-400">$5,234</p>
+                                {portfolioLoading ? (
+                                    <div className="h-8 w-20 bg-gray-700/50 animate-pulse rounded"></div>
+                                ) : (
+                                    <p className={`text-2xl font-bold ${calculateProfit() >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+                                        ${Math.abs(calculateProfit()).toLocaleString(undefined, {
+                                            minimumFractionDigits: 2,
+                                            maximumFractionDigits: 2
+                                        })}
+                                        {calculateProfit() < 0 ? ' Loss' : ''}
+                                    </p>
+                                )}
                             </div>
                             <div>
                                 <p className="text-sm text-gray-400">Balance</p>
-                                <p className="text-2xl font-bold text-white">
-                                    ${balance.toLocaleString(undefined, {
-                                    minimumFractionDigits: 2,
-                                    maximumFractionDigits: 2
-                                })}
-                                </p>
+                                {loading ? (
+                                    <div className="h-8 w-24 bg-gray-700/50 animate-pulse rounded"></div>
+                                ) : (
+                                    <p className="text-2xl font-bold text-white">
+                                        ${balance.toLocaleString(undefined, {
+                                        minimumFractionDigits: 2,
+                                        maximumFractionDigits: 2
+                                    })}
+                                    </p>
+                                )}
                             </div>
                         </div>
                     </section>
 
                     {/* Recent Activity */}
                     <section className="md:col-span-2 bg-gray-800/50 backdrop-blur-sm rounded-xl p-6 shadow-lg border border-white/10">
-                        <h2 className="text-2xl font-bold text-white mb-4">Recent Activity</h2>
-                        {transactions.length > 0 ? (
-                            <div className="space-y-4">
-                                {transactions.map((transaction) => (
-                                    <div key={transaction.id} className="bg-gray-700/30 rounded-lg p-4 border border-white/5">
-                                        <div className="flex justify-between items-center">
-                                            <div>
-                                                <p className="text-white font-medium">
-                                                    {transaction.type === 'BUY'
-                                                        ? 'Bought'
-                                                        : transaction.type === 'SELL'
-                                                            ? 'Sold'
-                                                            : 'Traded'}{' '}
-                                                    {transaction.stockSymbol}
-                                                </p>
+                        <div className="flex justify-between items-center mb-4">
+                            <h2 className="text-2xl font-bold text-white">Recent Activity</h2>
+                            <div className="flex items-center gap-2">
+                                <div className="text-sm text-gray-400">
+                                    {filteredTransactions.length} transaction{filteredTransactions.length !== 1 ? 's' : ''}
+                                </div>
+                                <div className="relative" ref={filterDropdownRef}>
+                                    <button 
+                                        onClick={() => setShowFilterDropdown(!showFilterDropdown)}
+                                        className="p-1.5 text-gray-400 hover:text-white bg-gray-700/30 rounded border border-white/5 flex items-center gap-1"
+                                    >
+                                        <FunnelIcon className="h-4 w-4" />
+                                        <span className="text-xs">
+                                            {transactionFilter === 'ALL' ? 'All' : 
+                                             transactionFilter === 'BUY' ? 'Buys' :
+                                             transactionFilter === 'SELL' ? 'Sells' :
+                                             transactionFilter === 'LOOTBOX' ? 'Purchases' :
+                                             transactionFilter === 'LOOTBOX_REDEEM' ? 'Redeems' : 'All'}
+                                        </span>
+                                    </button>
+                                    {showFilterDropdown && (
+                                        <div className="absolute right-0 mt-1 w-36 bg-gray-800 border border-white/10 rounded-md shadow-lg z-10">
+                                            <ul className="py-1">
+                                                <li 
+                                                    className={`px-3 py-2 text-sm cursor-pointer hover:bg-gray-700 ${transactionFilter === 'ALL' ? 'bg-blue-900/50 text-white' : 'text-gray-300'}`}
+                                                    onClick={() => {
+                                                        setTransactionFilter('ALL');
+                                                        setShowFilterDropdown(false);
+                                                    }}
+                                                >
+                                                    All Transactions
+                                                </li>
+                                                <li 
+                                                    className={`px-3 py-2 text-sm cursor-pointer hover:bg-gray-700 ${transactionFilter === 'BUY' ? 'bg-blue-900/50 text-white' : 'text-gray-300'}`}
+                                                    onClick={() => {
+                                                        setTransactionFilter('BUY');
+                                                        setShowFilterDropdown(false);
+                                                    }}
+                                                >
+                                                    Stock Buys
+                                                </li>
+                                                <li 
+                                                    className={`px-3 py-2 text-sm cursor-pointer hover:bg-gray-700 ${transactionFilter === 'SELL' ? 'bg-blue-900/50 text-white' : 'text-gray-300'}`}
+                                                    onClick={() => {
+                                                        setTransactionFilter('SELL');
+                                                        setShowFilterDropdown(false);
+                                                    }}
+                                                >
+                                                    Stock Sells
+                                                </li>
+                                                <li 
+                                                    className={`px-3 py-2 text-sm cursor-pointer hover:bg-gray-700 ${transactionFilter === 'LOOTBOX' ? 'bg-blue-900/50 text-white' : 'text-gray-300'}`}
+                                                    onClick={() => {
+                                                        setTransactionFilter('LOOTBOX');
+                                                        setShowFilterDropdown(false);
+                                                    }}
+                                                >
+                                                    Lootbox Purchases
+                                                </li>
+                                                <li 
+                                                    className={`px-3 py-2 text-sm cursor-pointer hover:bg-gray-700 ${transactionFilter === 'LOOTBOX_REDEEM' ? 'bg-blue-900/50 text-white' : 'text-gray-300'}`}
+                                                    onClick={() => {
+                                                        setTransactionFilter('LOOTBOX_REDEEM');
+                                                        setShowFilterDropdown(false);
+                                                    }}
+                                                >
+                                                    Lootbox Redeems
+                                                </li>
+                                            </ul>
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+                        </div>
+                        {filteredTransactions.length > 0 ? (
+                            <div className="h-96 overflow-y-auto pr-2 custom-scrollbar">
+                                <div className="space-y-4">
+                                    {filteredTransactions.map((transaction) => (
+                                        <div key={transaction.id} className="bg-gray-700/30 rounded-lg p-4 border border-white/5">
+                                            <div className="flex justify-between items-center">
+                                                <div>
+                                                    <p className="text-white font-medium">
+                                                        {transaction.type === 'BUY'
+                                                            ? 'Bought'
+                                                            : transaction.type === 'SELL'
+                                                                ? 'Sold'
+                                                            : transaction.type === 'LOOTBOX'
+                                                                ? 'Purchased'
+                                                                : transaction.type === 'LOOTBOX_REDEEM'
+                                                                    ? 'Redeemed'
+                                                                    : 'Traded'}{' '}
+                                                        {transaction.type === 'LOOTBOX' 
+                                                            ? 'Lootbox'
+                                                            : transaction.type === 'LOOTBOX_REDEEM'
+                                                                ? `${transaction.stockSymbol} from Lootbox`
+                                                                : transaction.stockSymbol}
+                                                    </p>
+                                                    <p className="text-sm text-gray-400">
+                                                        {transaction.type === 'LOOTBOX'
+                                                            ? `Cost: $${transaction.price.toFixed(2)}`
+                                                            : transaction.type === 'LOOTBOX_REDEEM'
+                                                                ? `Value: $${transaction.price.toFixed(2)}`
+                                                                : `${transaction.quantity} shares at $${transaction.price.toFixed(2)}`}
+                                                    </p>
+                                                </div>
                                                 <p className="text-sm text-gray-400">
-                                                    {transaction.quantity} shares at ${transaction.price.toFixed(2)}
+                                                    {formatRelativeTime(transaction.timestamp)}
                                                 </p>
                                             </div>
-                                            <p className="text-sm text-gray-400">
-                                                {formatRelativeTime(transaction.timestamp)}
-                                            </p>
                                         </div>
-                                    </div>
-                                ))}
+                                    ))}
+                                </div>
                             </div>
                         ) : (
-                            <p className="text-white">No recent activity</p>
+                            <div className="h-96 flex items-center justify-center text-gray-400 bg-gray-800/30 rounded-lg border border-white/5">
+                                <p>
+                                    {transactions.length === 0 
+                                        ? "No recent activity" 
+                                        : transactionFilter === 'BUY'
+                                            ? "No stock purchases found"
+                                            : transactionFilter === 'SELL'
+                                                ? "No stock sales found"
+                                                : transactionFilter === 'LOOTBOX'
+                                                    ? "No lootbox purchases found"
+                                                    : transactionFilter === 'LOOTBOX_REDEEM'
+                                                        ? "No lootbox redemptions found"
+                                                        : "No matching transactions found"}
+                                </p>
+                            </div>
                         )}
                     </section>
                 </div>


### PR DESCRIPTION
- added a transaction record when a user redeems a lootbox to get a stock
- updated the profile page to display both types of lootbox transactions
- made recent activity into a scrollable container
- added the ability to use a dropdown filter that allows to filter transactions by type
- added a counter that shows how many transactions are currently displayed (and updates when filters applied)
- the portfolio value shows the user's actual portfolio value instead of dummy value
- it is calculated based on the quantity and price of each stock
- win rate shows the user's actual win rate instead of dummy value
- the win rate calculation algorithm checks if trades were profitable
- basically, it groups transactions by stock symbol to analyze each stock's trading performance
- after, it calculates average buy and sell prices for each stock
- total profit calculates total profit from all buy and sell transactions
- shows "loss" indicator when profit is negative
- fixed an issue with lootbox purchases showing database ids
- added special handling for LOOTBOX and LOOTBOX_REDEEM transaction types
- created MyPage component in community/myPage/page.tsx
- myPage shows friend activity/transaction history (like the home page)
- updated community/page.tsx to render the myPage component when the myPage tab is actually active
- the global chat in the community page now has a fixed height container that is independently scrollable
- chat content stays within its container, with its own scrollbar so you can see new messages without scrolling the entire page.
- chat automatically scrolls to the bottom when new messages arrive or when the component first loads